### PR TITLE
Update Version Number and md5sums for PureRef.

### DIFF
--- a/00_not_for_me/pure-ref/PKGBUILD
+++ b/00_not_for_me/pure-ref/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Fabio 'Lolix' Loli <lolix@disroot.org> -> https://github.com/FabioLolix
 
 pkgname=pureref
-pkgver=1.9.1
+pkgver=1.9.2
 pkgrel=1
 pkgdesc="Simple and lightweight tool for artists to organize and view their reference images"
 arch=('x86_64')
@@ -15,9 +15,8 @@ depends=('hicolor-icon-theme'
 provides=('pureref')
 conflicts=('pureref')
 source=(local://PureRef-${pkgver}_x64.deb)
-md5sums=('3aece649e8c04d34b6b4191266def4ec')
+md5sums=('5863dc94c62a992aa1b627e207bee152')
 
 package() {
   bsdtar -xf "${srcdir}/data.tar.xz" -C "${pkgdir}/"
-#  install -d ${pkgdir}/usr/share/licenses/${pkgname}
 }


### PR DESCRIPTION
This was a useful starting point for me installing pureref on my manjaro machine. However, it was out of date so I went ahead and updated it to the latest version and thought I would contribute back.

Thank you very much for the head start. Cheers!