### PR TITLE
Fix lyrionmusicserver for Perl 5.42+

### DIFF
--- a/lyrionmusicserver/PKGBUILD
+++ b/lyrionmusicserver/PKGBUILD
@@ -35,7 +35,9 @@ prepare() {
 }
 
 build() {
+  cp ../*.patch "slimserver-vendor/CPAN"
   cd "slimserver-vendor/CPAN"
+  patch buildme.sh buildme.sh.patch
   ./buildme.sh -t
 }
 
@@ -49,7 +51,4 @@ package() {
   cp -a * "${pkgdir}/opt/${pkgname}"
   cd "${srcdir}/slimserver-vendor"
   cp -a CPAN/build/5.*/lib/*/*linux*/* "${pkgdir}/opt/${pkgname}/CPAN"
-
-  touch "${pkgdir}/opt/lyrionmusicserver/Logs/server.log"
-  touch "${pkgdir}/opt/lyrionmusicserver/Logs/perfmon.log"
 }

--- a/lyrionmusicserver/PKGBUILD
+++ b/lyrionmusicserver/PKGBUILD
@@ -2,22 +2,22 @@
 # Maintainer: Stefan Sielaff <aur AT stefan-sielaff DOT de>
 
 pkgname=lyrionmusicserver
-pkgver=9.0.2
-pkgrel=1
+pkgver=9.0.0
+pkgrel=2
 pkgdesc="Slimserver for Logitech Squeezebox players. This server is also called Logitech Media Server)"
 arch=(i686 x86_64 armv7h aarch64)
 url="https://github.com/LMS-Community/slimserver"
 license=(GPL-2.0-only)
-depends=('perl>=5.40' 'perl<=5.42' glibc gcc-libs zlib)
+depends=('perl>=5.40' 'perl<5.43' glibc gcc-libs zlib)
 makedepends=(git rsync yasm clang)
 install=lyrionmusicserver.install
 options=(!strip)
 source=("git+https://github.com/LMS-Community/slimserver.git#tag=${pkgver}"
         "git+https://github.com/LMS-Community/slimserver-vendor.git"
         'lyrionmusicserver.service')
-sha256sums=('78401ac07fd4fedfa6c9d7e3b63000261bc3f5c4bf87277b5654ca397db17ba1'
+sha256sums=('267b298f3d0de910bb4cd566218a11bbab3d63227b5f223c6d5a5ee32534e402'
             'SKIP'
-            'f48d1a1eb34d88c69c78a78d9f00b772e0d5613e5f476304d68a5ba0ee4c3547')
+            'eec545f10a8048c9d996db52deff1d24a3d83ef151c7464e26f1c26d5111104f')
 
 prepare() {
     cd "slimserver/Bin"

--- a/lyrionmusicserver/Scan.xs.patch
+++ b/lyrionmusicserver/Scan.xs.patch
@@ -1,0 +1,24 @@
+220c220
+< _scan( char *, char *suffix, PerlIO *infile, SV *path, int filter, int md5_size, int md5_offset )
+---
+> _scan( char *self, char *suffix, PerlIO *infile, SV *path, int filter, int md5_size, int md5_offset )
+272c272
+< _find_frame( char *, char *suffix, PerlIO *infile, SV *path, int offset )
+---
+> _find_frame( char *self, char *suffix, PerlIO *infile, SV *path, int offset )
+288c288
+< _find_frame_return_info( char *, char *suffix, PerlIO *infile, SV *path, int offset )
+---
+> _find_frame_return_info( char *self, char *suffix, PerlIO *infile, SV *path, int offset )
+312c312
+< is_supported(char *, SV *path)
+---
+> is_supported(char *self, SV *path)
+328c328
+< type_for(char *, SV *suffix)
+---
+> type_for(char *self, SV *suffix)
+366c366
+< extensions_for(char *, SV *type)
+---
+> extensions_for(char *self, SV *type)

--- a/lyrionmusicserver/buildme.sh.patch
+++ b/lyrionmusicserver/buildme.sh.patch
@@ -1,0 +1,23 @@
+diff --git a/CPAN/buildme.sh b/CPAN/buildme.sh
+index 98c84f6..e3720c7 100755
+--- a/CPAN/buildme.sh
++++ b/CPAN/buildme.sh
+@@ -543,6 +543,10 @@ function build_module {
+ 
+     cd "${module}"
+ 
++    if [ "${module}" = "Audio-Scan-1.10" ]; then
++        patch Scan.xs ../Scan.xs.patch || true
++    fi
++
+     if [ $local_use_hints -eq 1 ]; then
+         # Always copy in our custom hints for OSX
+         cp -R ../hints .
+@@ -750,6 +754,7 @@ function build {
+ 
+             tar_wrapper zxf EV-4.03.tar.gz
+             cd EV-4.03
++            patch typemap ../typemap.patch || true
+             patch -p0 < ../EV-llvm-workaround.patch # patch to avoid LLVM bug 9891
+             if [ "$OS" = "Darwin" ]; then
+                 if [ $PERL_58 ]; then

--- a/lyrionmusicserver/lyrionmusicserver.service
+++ b/lyrionmusicserver/lyrionmusicserver.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Lyrion Media Server Daemon
+Description=Logitech Media Server Daemon
 After=network.target
 
 [Service]
@@ -12,8 +12,8 @@ ExecStart=/opt/lyrionmusicserver/slimserver.pl \
         --prefsdir /opt/lyrionmusicserver/prefs \
         --cachedir /opt/lyrionmusicserver/cache \
         --logdir /opt/lyrionmusicserver/Logs \
-         --pidfile ${RUNTIME_DIRECTORY}/slimserver.pid \
-         --noimage --novideo
+        --pidfile ${RUNTIME_DIRECTORY}/slimserver.pid \
+        --noimage --novideo
 
 [Install]
 WantedBy=multi-user.target

--- a/lyrionmusicserver/typemap.patch
+++ b/lyrionmusicserver/typemap.patch
@@ -1,0 +1,10 @@
+39,43c39,41
+< 	if (!(SvROK ($arg) && SvOBJECT (SvRV ($arg))
+<               && (SvSTASH (SvRV ($arg)) == stash_" . ($type =~ /ev_(\S+)/, "$1") . "
+<                   || sv_derived_from ($arg, \"EV::" . ($type =~ /ev_(\S+)/, ucfirst "$1") . "\"))))
+<           croak (\"object is not of type EV::" . ($type =~ /ev_(\S+)/, ucfirst "$1") . "\");
+< 	$var = ($type)SvPVX (SvRV ($arg));
+---
+>     if (!(SvROK($arg) && SvOBJECT(SvRV($arg)) && sv_derived_from($arg, \"EV::Watcher\")))
+>         croak(\"$var is not of type EV::Watcher\");
+>     $var = ($type)SvPVX(SvRV($arg));


### PR DESCRIPTION
This PR adds some patches to fix the build of `lyrionmusicserver` for Perl 5.42+. The same could be applied to the `*-git` version of the package, as well as the deprecated `logitechmediaserver` variants.

Note that this is likely a temporary stopgap, since any upstream changes to the files will mean that the patch files will likely no longer work.

Cheers.